### PR TITLE
Allow customizing cors response headers [fixes #12]

### DIFF
--- a/lib/fortune.js
+++ b/lib/fortune.js
@@ -80,8 +80,8 @@ Fortune.prototype._init = function(options) {
   router = this.router;
 
   // Setup express.
-  if(typeof options.cors == 'boolean' && options.cors) {
-    router.use(allowCrossDomain);
+  if(typeof options.cors == 'boolean' || typeof options.cors == 'object' && options.cors) {
+    router.use(allowCrossDomain(options.cors));
   }
   router.disable('x-powered-by');
   router.use(express.bodyParser());
@@ -360,17 +360,34 @@ Fortune.prototype._resource = '';
 
 
 // Default Cross-Origin Resource Sharing setup.
-function allowCrossDomain(req, res, next) {
-  if(!req.get('Origin')) return next();
-  res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers', 'Accept, Content-Type, Authorization, X-Requested-With');
-  res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, PATCH, DELETE');
-  res.header('Access-Control-Allow-Credentials', 'true');
-  // intercept OPTIONS method
-  if(req.method == 'OPTIONS') {
-    res.send(200);
-  } else {
-    next();
+function allowCrossDomain(cors) {
+
+  var headers = cors.headers || ['Accept', 'Content-Type', 'Authorization', 'X-Requested-With'],
+      methods = cors.methods || ['GET', 'PUT', 'POST', 'PATCH', 'DELETE'],
+      origins = cors.origins || '*',
+      credentials = cors.credentials || true;
+
+  return function(req, res, next) {
+    if(!req.get('Origin')) return next();
+
+    if(origins !== '*') {
+      if(origins.indexOf(req.get('Origin'))) {
+        origins = req.get('Origin');
+      } else {
+        next();
+      }
+    }
+
+    res.header('Access-Control-Allow-Origin', origins);
+    res.header('Access-Control-Allow-Headers', headers.join(', '));
+    res.header('Access-Control-Allow-Methods', methods.join(', '));
+    res.header('Access-Control-Allow-Credentials', credentials.toString());
+    // intercept OPTIONS method
+    if(req.method == 'OPTIONS') {
+      res.send(200);
+    } else {
+      next();
+    }
   }
 }
 


### PR DESCRIPTION
Allows for the following API to customize the CORS response headers:

```
fortune({
  cors: {
    headers: ['X-SignedInAs'/*, ... */],
    methods: ['POST', 'PATCH'],
    origins: ['http://localhost:8000'],
    credentials: false
  }
});
```

Any options left out will default to their current hardcoded values.

The middleware will match the request's Origin header against the list of known origins and pass it back in the Access-Control-Allow-Origin header if it's in the list. If not, it will be rejected.

I did not update the README with this, leaving it up to you however you want to document it.
