### PR TITLE
href attribute for associations was generated incorrectly

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -526,7 +526,7 @@ function appendLinks(body) {
       var name = [key, association.key].join('.');
       body.links[name] = {
         href: baseUrl + '/' + (!!namespace ? namespace + '/' : '') +
-          key + '/{' + name + '}',
+          association.type + '/{' + name + '}',
         type: association.type
       };
     });


### PR DESCRIPTION
When using url-mode (baseUrl is defined), the href attribute is generated incorrectly:

``` JSON
{
  "posts": [ ... ],
  "links": {
    "posts.comments": {
      "href": "http://example.com/post/{posts.comments}",
      "type": "comments"
    }
  }
}
```

Whereas the comments resource would be at http://example.com/comments/:id
