### PR TITLE
`sendError` should make sure that the detail is a string so it shows up in the response

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -44,7 +44,7 @@ function route(name, model) {
     if(!!error) console.trace(error);
     var object = {
       error: errorMessages[status],
-      detail: error
+      detail: error.toString()
     }, str = production ?
       JSON.stringify(object, null, null) :
       JSON.stringify(object, null, 2) + '\n';


### PR DESCRIPTION
`JSON.stringify` does not convert `Error` objects to strings.
