### PR TITLE
If resolve is called with no values, `error` will be `undefined` here.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -44,7 +44,7 @@ function route(name, model) {
     if(!!error) console.trace(error);
     var object = {
       error: errorMessages[status],
-      detail: error.toString()
+      detail: error ? error.toString() : ''
     }, str = production ?
       JSON.stringify(object, null, null) :
       JSON.stringify(object, null, 2) + '\n';


### PR DESCRIPTION
Set the `detail` to an empty string in this case.
