### PR TITLE
Update keystore example to proper request method

### DIFF
--- a/examples/keystore.js
+++ b/examples/keystore.js
@@ -41,7 +41,7 @@ var app = fortune({
       , id = user.id || request.path.split('/').pop();
 
     // require a password on user creation
-    if(request.method == 'post') {
+    if(request.method.toLowerCase() == 'post') {
       if(!!password) {
         return hashPassword(user, password);
       } else {


### PR DESCRIPTION
request.method usually returns the method in all caps because that is how it is usually sent. A header will look something like:

POST /users HTTP/1.1
Host: localhost:1337
Content-Type: application/json

so request.method will equal "POST"
