### PR TITLE
Allow singular POST and singular PUT

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -133,7 +133,20 @@ function route(name, model) {
       return sendError(req, res, 412);
     }
 
-    createResources(model, req.body[collection])
+    Promise.resolve().then(function () {
+      // check both plural and singular
+      var resources = req.body[collection] || req.body[name];
+      if (!resources) {
+        var error = new Error('expected payload to contain one of: ' +
+          JSON.stringify([name, collection]));
+        error.status = 400;
+        throw error;
+      }
+      if (!Array.isArray(resources)) {
+        resources = [resources]; // only posting one
+      }
+      return createResources(model, resources);
+    })
 
     // handle creation of linked resources
     .then(function (resources) {
@@ -180,7 +193,11 @@ function route(name, model) {
         return linked;
       });
     }, function (error) {
-      sendError(req, res, 500, error);
+      if (typeof error.status === 'number') { // error we deliberately threw
+        sendError(req, res, error.status, error);
+      } else { //unknown error
+        sendError(req, res, 500, error);
+      }
     })
 
     // send the response
@@ -406,11 +423,16 @@ function route(name, model) {
       return sendError(req, res, 412);
     }
 
-    try {
-      update = req.body[collection][0];
-      if (!update) return sendError(req, res, 400);
-    } catch(error) {
-      return sendError(req, res, 400, error);
+    var update = req.body[collection] || req.body[name];
+    if (!update) {
+      var error = new Error('expected payload to contain one of: ' +
+        JSON.stringify([name, collection]));
+      error.status = 400;
+      return sendError(req, res, error.status, error);
+    }
+
+    if (Array.isArray(update)) {
+      update = update[0];
     }
 
     // try to find the resource by ID

--- a/test/post.js
+++ b/test/post.js
@@ -1,0 +1,139 @@
+var inflect = require('i')();
+var should = require('should');
+var _ = require('lodash');
+var RSVP = require('rsvp');
+var request = require('supertest');
+
+var Promise = RSVP.Promise;
+
+_.each(global.options, function (options, port) {
+  var baseUrl = 'http://localhost:' + port;
+
+
+  describe('using "' + options.adapter + '" adapter', function () {
+
+    before(function (done) {
+      done();
+    });
+
+    var ids = [];
+
+    describe('post a single resource', function () {
+      it('post dilbert', function (done) {
+        request(baseUrl)
+          .post('/people')
+          .send({
+            person: {
+              "name": "Dilbert",
+              "appearances": 3457
+            }
+          })
+          .expect(201)
+          .expect('Content-Type', /json/)
+          .end(function (error, response) {
+            response.body.people.should.have.length(1);
+            response.body.people[0].name.should.equal('Dilbert');
+            (typeof response.body.people[0].id).should.equal('string');
+            ids.push(response.body.people[0].id);
+            should.not.exist(error);
+            done();
+          });
+      });
+    });
+
+    describe('post a bad resource', function () {
+      it('post dilbert', function (done) {
+        request(baseUrl)
+          .post('/people')
+          .send({
+            ppl: {
+              "name": "Dilbert",
+              "appearances": 3457
+            }
+          })
+          .expect(400)
+          .end(function (error, response) {
+            should.not.exist(error);
+            should.exist(response);
+            should.exist(response.error);
+            should.exist(response.body);
+            response.body.toString.should.match(/expected payload to contain/,
+              'gives a meaningful error so the user can recover');
+            done();
+          });
+      });
+    });
+
+    // the server is forgiving - if you mess up
+    // singular/plural, then it understands what you mean
+    describe('post a single resource - mix plural key with singular value', function () {
+      it('post dilbert', function (done) {
+        request(baseUrl)
+          .post('/people')
+          .send({
+            people: {
+              "name": "Dilbert",
+              "appearances": 3457
+            }
+          })
+          .expect(201)
+          .expect('Content-Type', /json/)
+          .end(function (error, response) {
+            response.body.people.should.have.length(1);
+            response.body.people[0].name.should.equal('Dilbert');
+            (typeof response.body.people[0].id).should.equal('string');
+            ids.push(response.body.people[0].id);
+            should.not.exist(error);
+            done();
+          });
+      });
+    });
+
+    // the server is forgiving - if you mess up
+    // singular/plural, then it understands what you mean
+    describe('post a single resource - mix singular key with plural value', function () {
+      it('post dilbert', function (done) {
+        request(baseUrl)
+          .post('/people')
+          .send({
+            person: [
+              {
+                "name": "Dilbert",
+                "appearances": 3457
+              }
+            ]
+          })
+          .expect(201)
+          .expect('Content-Type', /json/)
+          .end(function (error, response) {
+            response.body.people.should.have.length(1);
+            response.body.people[0].name.should.equal('Dilbert');
+            (typeof response.body.people[0].id).should.equal('string');
+            ids.push(response.body.people[0].id);
+            should.not.exist(error);
+            done();
+          });
+      });
+    });
+
+    after(function (done) {
+      RSVP.all(ids.map(function (id) {
+          return new Promise(function (resolve) {
+            request(baseUrl)
+              .del('/people/' + id)
+              .expect(204)
+              .end(function (error) {
+                should.not.exist(error);
+                resolve();
+              });
+          });
+        })).then(function () {
+          done();
+        }, function () {
+          throw new Error('Failed to delete resources.');
+        });
+    });
+
+  });
+
+});

--- a/test/put.js
+++ b/test/put.js
@@ -1,0 +1,88 @@
+var inflect = require('i')();
+var should = require('should');
+var _ = require('lodash');
+var RSVP = require('rsvp');
+var request = require('supertest');
+
+var Promise = RSVP.Promise;
+
+_.each(global.options, function (options, port) {
+  var baseUrl = 'http://localhost:' + port;
+
+
+  describe('using "' + options.adapter + '" adapter', function () {
+
+    before(function (done) {
+      done();
+    });
+
+    var ids = [];
+
+    describe('put a single resource', function () {
+      it('put dilbert', function (done) {
+        // first post dilbert
+        request(baseUrl)
+          .post('/people')
+          .send({
+            person: {
+              "name": "Dilbert",
+              "appearances": 3000
+            }
+          })
+          .expect(201)
+          .expect('Content-Type', /json/)
+          .end(function (error, response) {
+            should.not.exist(error);
+            var id = response.body.people[0].id;
+            JSON.stringify(response.body.people[0]).should.equal(JSON.stringify({
+              "id": id,
+              "name": "Dilbert",
+              "appearances": 3000
+            }));
+            // then update him
+            request(baseUrl)
+              .put('/people/' + id)
+              .send({
+                person: {
+                  "name": "Dilbert",
+                  "appearances": 9000
+                }
+              })
+              .expect(200)
+              .expect('Content-Type', /json/)
+              .end(function (error, response) {
+                should.not.exist(error);
+                should.exist(response);
+                response.body.people.should.have.length(1);
+                JSON.stringify(response.body.people[0]).should.equal(JSON.stringify({
+                  "id": id,
+                  "name": "Dilbert",
+                  "appearances": 9000
+                }));
+                done();
+              });
+          });
+      });
+    });
+
+    after(function (done) {
+      RSVP.all(ids.map(function (id) {
+          return new Promise(function (resolve) {
+            request(baseUrl)
+              .del('/people/' + id)
+              .expect(204)
+              .end(function (error) {
+                should.not.exist(error);
+                resolve();
+              });
+          });
+        })).then(function () {
+          done();
+        }, function () {
+          throw new Error('Failed to delete resources.');
+        });
+    });
+
+  });
+
+});

--- a/test/run.js
+++ b/test/run.js
@@ -52,6 +52,8 @@ function runTests(adapters) {
       .reporter('spec')
       .ui('bdd')
       .addFile(path.join(location, 'all.js'))
+      .addFile(path.join(location, 'post.js'))
+      .addFile(path.join(location, 'put.js'))
       .run(function (code) {
         process.exit(code);
       });


### PR DESCRIPTION
So currently the server accepts something like this to be POSTed:

```js
{
  people: [
    { name: "Dilbert"},
    { name: "Wally"}
  ]
}
```

But not this:

```js
{
  person: { name: "Dilbert"}
}
```

This doesn't seem to conform to the spec, and in particular it breaks when I try to hook up a basic Ember app like [ember-cli-todos](https://github.com/WMeldon/ember-cli-todos) to this server.

In this PR, I've modified the server so that it accepts any combination of e.g. `person`/`people` plus an array/singleton. I think being forgiving makes sense, since otherwise people might get frustrated trying to get their inflections to work correctly (I know I did). I dunno if it conforms exactly to the spec, but since we can programmatically determine what the user meant using `Array.isArray`, I don't see the harm in it.