### PR TITLE
Fix inverse typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ app.defineType('user', {
 
 app.defineType('group', {
   name: { type: String },
-  members: { link: 'user', inverse: 'group', isArray: true }
+  members: { link: 'user', inverse: 'groups', isArray: true }
 })
 ```
 


### PR DESCRIPTION
Group should be plural.