### PR TITLE
json_api serializer now access camel case fields correctly

### DIFF
--- a/lib/serializer/serializers/json_api/helpers.js
+++ b/lib/serializer/serializers/json_api/helpers.js
@@ -136,6 +136,7 @@ export function mapRecord (type, record) {
     if (field === keys.primary) continue
 
     const fieldDefinition = fields[field]
+    const originalFieldName = field
 
     // Per the recommendation, dasherize keys.
     if (inflectKeys)
@@ -144,7 +145,7 @@ export function mapRecord (type, record) {
 
     // Handle meta/attributes.
     if (!fieldDefinition || fieldDefinition[keys.type]) {
-      const value = record[field]
+      const value = record[originalFieldName]
 
       if (!fieldDefinition) clone[reservedKeys.meta][field] = value
       else clone[reservedKeys.attributes][field] = value

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -2,6 +2,7 @@ export default [
   {
     id: 1,
     name: 'John Doe',
+    camelCaseField: 'Something with a camel case field',
     birthday: new Date(1992, 11, 7),
     spouse: 2,
     pets: [ 1 ],

--- a/test/integration/serializers/json_api.js
+++ b/test/integration/serializers/json_api.js
@@ -48,7 +48,6 @@ test('create record', fetchTest('/animals', {
     .getTime() < 60 * 1000, 'date is close enough')
 }))
 
-
 test('create record with existing ID should fail', fetchTest('/users', {
   method: 'post',
   headers: { 'Accept': mediaType, 'Content-Type': mediaType },
@@ -143,6 +142,15 @@ test('filter a collection', fetchTest('/users?filter[name]=John Doe', {
   t.deepEqual(
     response.body.data.map(record => record.attributes.name).sort(),
     [ 'John Doe' ], 'match is correct')
+}))
+
+
+test('dasherizes the camel cased fields', fetchTest('/users/1', {
+  method: 'get',
+  headers: { 'Accept': mediaType }
+}, (t, response) => {
+  t.equal(response.body.data.attributes['camel-case-field'],
+    'Something with a camel case field', 'camel case field is correct')
 }))
 
 

--- a/test/integration/test_instance.js
+++ b/test/integration/test_instance.js
@@ -13,6 +13,7 @@ export default (t, options) => {
 
   .defineType('user', {
     name: { type: String },
+    camelCaseField: { type: String },
     birthday: { type: Date },
     picture: { type: Buffer },
 


### PR DESCRIPTION
This functionality was working in beta 22 but started failing in beta 23.

I had problems getting the browserify tests to run on my machine and wasn't sure if I was just missing dependencies or what.