### PR TITLE
Send request metadata through to adapters

### DIFF
--- a/lib/adapter/adapters/memory/index.js
+++ b/lib/adapter/adapters/memory/index.js
@@ -26,7 +26,8 @@ export default Adapter => class MemoryAdapter extends Adapter {
   }
 
 
-  find (type, ids, options = {}) {
+  find (type, ids, options) {
+    if (!options) options = {}
     if (ids && !ids.length) return super.find()
 
     const { db, recordTypes } = this

--- a/lib/adapter/index.js
+++ b/lib/adapter/index.js
@@ -66,6 +66,7 @@ export default class Adapter {
    *
    * @param {String} type
    * @param {Object[]} records
+   * @param {Object} [meta]
    * @return {Promise}
    */
   create () {
@@ -128,6 +129,7 @@ export default class Adapter {
    * @param {String} type
    * @param {String[]|Number[]} [ids]
    * @param {Object} [options]
+   * @param {Object} [meta]
    * @return {Promise}
    */
   find () {
@@ -173,6 +175,7 @@ export default class Adapter {
    *
    * @param {String} type
    * @param {Object[]} updates
+   * @param {Object} [meta]
    * @return {Promise}
    */
   update () {
@@ -187,6 +190,7 @@ export default class Adapter {
    *
    * @param {String} type
    * @param {String[]|Number[]} [ids]
+   * @param {Object} [meta]
    * @return {Promise}
    */
   delete () {

--- a/lib/dispatch/check_links.js
+++ b/lib/dispatch/check_links.js
@@ -10,9 +10,10 @@ import { BadRequestError } from '../common/errors'
  * @param {Array} links - An array of strings indicating which fields are
  * links. Need to pass this so that it doesn't get computed each time.
  * @param {Object} adapter
+ * @param {Object} meta
  * @return {Promise}
  */
-export default function checkLinks (record, fields, links, adapter) {
+export default function checkLinks (record, fields, links, adapter, meta) {
   return Promise.all(links.map(field => new Promise((resolve, reject) => {
     const ids = Array.isArray(record[field]) ? record[field] :
       !(field in record) || record[field] === null ? [] : [ record[field] ]
@@ -21,7 +22,7 @@ export default function checkLinks (record, fields, links, adapter) {
     adapter.find(fields[field][keys.link], ids, {
       // Don't need the entire records.
       fields: { [fields[field][keys.inverse]]: true }
-    })
+    }, meta)
 
     .then(records => records.length < ids.length ?
       reject(new BadRequestError(

--- a/lib/dispatch/create.js
+++ b/lib/dispatch/create.js
@@ -21,7 +21,7 @@ export default function (context) {
     throw new BadRequestError(
       `There are no valid records in the request.`)
 
-  const { type } = context.request
+  const { type, meta } = context.request
   const transform = transforms[type]
   const fields = recordTypes[type]
   const links = Object.keys(fields)
@@ -44,12 +44,12 @@ export default function (context) {
     enforce(type, record, fields)
 
     // Ensure referential integrity.
-    return checkLinks(record, fields, links, adapter)
+    return checkLinks(record, fields, links, adapter, meta)
   }))
   .then(() => adapter.beginTransaction())
   .then(t => {
     transaction = t
-    return transaction.create(type, records)
+    return transaction.create(type, records, meta)
   }))
 
   .then(createdRecords => {
@@ -98,7 +98,7 @@ export default function (context) {
 
     return Promise.all(Object.keys(updates)
       .map(type => updates[type].length ?
-        transaction.update(type, updates[type]) :
+        transaction.update(type, updates[type], meta) :
         Promise.resolve([])))
   })
 

--- a/lib/dispatch/delete.js
+++ b/lib/dispatch/delete.js
@@ -12,7 +12,7 @@ import * as updateHelpers from './update_helpers'
  * @return {Promise}
  */
 export default function (context) {
-  const { request: { type, ids } } = context
+  const { request: { type, ids, meta } } = context
   const { adapter, recordTypes, transforms } = this
   const updates = {}
   const fields = recordTypes[type]
@@ -23,7 +23,7 @@ export default function (context) {
   let transaction
   let records
 
-  return (ids ? adapter.find(type, ids) : Promise.resolve([]))
+  return (ids ? adapter.find(type, ids, null, meta) : Promise.resolve([]))
 
   .then(foundRecords => {
     records = foundRecords
@@ -46,7 +46,7 @@ export default function (context) {
 
   .then(t => {
     transaction = t
-    return transaction.delete(type, ids)
+    return transaction.delete(type, ids, meta)
   })
 
   .then(() => {
@@ -79,7 +79,7 @@ export default function (context) {
 
     return Promise.all(Object.keys(updates)
       .map(type => updates[type].length ?
-        transaction.update(type, updates[type]) :
+        transaction.update(type, updates[type], meta) :
         Promise.resolve([])))
   })
 

--- a/lib/dispatch/find.js
+++ b/lib/dispatch/find.js
@@ -6,13 +6,14 @@
  */
 export default function (context) {
   const { adapter } = this
-  const { type, ids, options } = context.request
+  const { type, ids, options, meta } = context.request
 
   if (!type) return context
 
   const args = [ type, ids ]
 
-  if (options) args.push(options)
+  args.push(options ? options : null)
+  if (meta) args.push(meta)
 
   return adapter.find(...args).then(records => {
     Object.defineProperty(context.response, 'records', {

--- a/lib/dispatch/include.js
+++ b/lib/dispatch/include.js
@@ -10,7 +10,7 @@ import { find } from '../common/array_proxy'
  */
 export default function (context) {
   const {
-    request: { type, ids, include },
+    request: { type, ids, include, meta },
     response: { records }
   } = context
 
@@ -62,7 +62,8 @@ export default function (context) {
 
       const args = [ currentType, currentIds ]
 
-      if (currentOptions) args.push(currentOptions)
+      args.push(currentOptions ? currentOptions : null)
+      if (meta) args.push(meta)
 
       return currentIds.length ? adapter.find(...args) : []
     }), Promise.resolve(records))

--- a/lib/dispatch/update.js
+++ b/lib/dispatch/update.js
@@ -26,7 +26,7 @@ export default function (context) {
   // Keyed by update, valued by hash of linked records.
   const linkedMap = new WeakMap()
 
-  const { type } = context.request
+  const { type, meta } = context.request
   const fields = recordTypes[type]
   const transform = transforms[type]
   const links = Object.keys(fields)
@@ -47,7 +47,7 @@ export default function (context) {
         if ('pull' in update) delete update.pull[field]
       }
 
-  return adapter.find(type, updates.map(update => update.id))
+  return adapter.find(type, updates.map(update => update.id), null, meta)
 
   .then(records => Promise.all(records.map(record => {
     const update = find(updates, update =>
@@ -81,7 +81,7 @@ export default function (context) {
       enforce(type, record, fields)
 
       // Ensure referential integrity.
-      return checkLinks(record, fields, links, adapter)
+      return checkLinks(record, fields, links, adapter, meta)
       .then(linked => {
         linkedMap.set(update, linked)
         return record
@@ -106,7 +106,7 @@ export default function (context) {
     for (let update of transformedUpdates)
       dropFields(update, fields)
 
-    return transaction.update(type, transformedUpdates)
+    return transaction.update(type, transformedUpdates, meta)
   })
 
   .then(() => {
@@ -226,7 +226,7 @@ export default function (context) {
 
     return Promise.all(Object.keys(relatedUpdates)
       .map(type => relatedUpdates[type].length ?
-        transaction.update(type, relatedUpdates[type]) :
+        transaction.update(type, relatedUpdates[type], meta) :
         Promise.resolve()))
   })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fortune",
   "description": "High-level I/O for web applications.",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "license": "MIT",
   "author": {
     "email": "0x8890@airmail.cc",


### PR DESCRIPTION
The change in the memory adapter was due to the transpiler using arguments.length as a way to do the default value on the options parameter:

```
value: function find(type, ids) {
    var options = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
```

Having the meta field caused this to break in the tests