### PR TITLE
fix type number cast value

### DIFF
--- a/lib/serializer/cast_value.js
+++ b/lib/serializer/cast_value.js
@@ -2,7 +2,7 @@ import { BadRequestError } from '../common/errors'
 
 
 const castByType = new WeakMap([
-  [ Number, x => parseInt(x, 10) ],
+  [ Number, x => parseFloat(x, 10) ],
 
   [ Date, x => {
     if (typeof x === 'string') {


### PR DESCRIPTION
Change parseInt to parseFloat in lib/serializer/cast_value.js at line 5

Issue #139