### PR TITLE
fix issue when matchByField is attempting to match boolean false

### DIFF
--- a/lib/adapter/adapters/common.js
+++ b/lib/adapter/adapters/common.js
@@ -119,7 +119,7 @@ function matchByField (fields, match) {
       field = keys[i]
       matches = match[field]
       if (!Array.isArray(match[field])) matches = [ matches ]
-      if (!find(matches, checkValue(fields[field], record[field])))
+      if (undefined === find(matches, checkValue(fields[field], record[field])))
         return false
     }
 


### PR DESCRIPTION
When using the default serializer/adapter, we were having trouble with the match parameter on a boolean field.

With a `company` type that has a Boolean `approved` field, we were attempting to hit this endpoint:
`GET /user?match[company]=false`

This was returning no results, even though we did have some records that matched.

...and searching for the inverse:
`GET /user?match[company]=true`
Worked great and we got results.

I was able to track down a line in `common.js` in the `matchByField` method that is checking for a falsey value returned from `find` as "no match". This does not work when the value found is actually `false`! :)

This pull request updates that line to instead compare against `undefined`, which will correctly be returned if `false` is not found.

Please let me know if you need anything else before merging. Thanks!