### PR TITLE
Specify range filter in adapter

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+##### 1.9.0 (2016-01-10)
+- Feature: specify `range` option in Adapter.
+
+
 ##### 1.8.1 (2016-01-06)
 - Fix: correctly use specified Promise implementation. Thanks [@mctep](https://github.com/mctep) for reporting!
 

--- a/lib/adapter/adapters/common.js
+++ b/lib/adapter/adapters/common.js
@@ -138,28 +138,32 @@ function matchByField (fields, match) {
 function matchByRange (fields, ranges) {
   var keys = Object.keys(ranges)
   var compare = {}
-  var i, field, fieldDefinition, fieldType, range, value
+  var i, field, fieldDefinition, fieldType, fieldIsArray, range, value
 
   return function (record) {
     for (i = keys.length; i--;) {
       field = keys[i]
       fieldDefinition = fields[field]
       fieldType = fieldDefinition[typeKey]
+      fieldIsArray = fieldDefinition[isArrayKey]
 
-      // Skip for non-singular, non-typed fields.
-      if (!fieldType || fieldDefinition[isArrayKey]) continue
+      // Skip for singular link fields.
+      if (!fieldType && !fieldIsArray) continue
 
       range = ranges[field]
       value = record[field]
 
       if (value == null) return false
+      if (fieldIsArray) value = value ? value.length : 0
 
-      if (!compare[field]) {
-        compare[field] = fieldType.compare ||
-          find(comparisons, findKey(fieldType))[1]
-        if (!compare[field])
-          throw new Error('Missing "compare" function.')
-      }
+      if (!compare[field])
+        if (!fieldIsArray) {
+          compare[field] = fieldType.compare ||
+            find(comparisons, findKey(fieldType))[1]
+          if (!compare[field])
+            throw new Error('Missing "compare" function.')
+        }
+        else compare[field] = find(comparisons, findKey(Number))[1]
 
       if (range[0] !== null && compare[field](value, range[0]) < 0)
         return false

--- a/lib/adapter/adapters/common.js
+++ b/lib/adapter/adapters/common.js
@@ -51,6 +51,11 @@ exports.applyOptions = function (count, fields, records, options, meta) {
 
   language = meta.language
 
+  if ('range' in options) {
+    records = filter(records, matchByRange(fields, options.range))
+    count = records.length
+  }
+
   if ('match' in options) {
     records = filter(records, matchByField(fields, options.match))
     count = records.length
@@ -122,6 +127,44 @@ function matchByField (fields, match) {
       matches = match[field]
       if (!Array.isArray(match[field])) matches = [ matches ]
       if (find(matches, checkValue(fields[field], record[field])) === void 0)
+        return false
+    }
+
+    return true
+  }
+}
+
+
+function matchByRange (fields, ranges) {
+  var keys = Object.keys(ranges)
+  var compare = {}
+  var i, field, fieldDefinition, fieldType, range, value
+
+  return function (record) {
+    for (i = keys.length; i--;) {
+      field = keys[i]
+      fieldDefinition = fields[field]
+      fieldType = fieldDefinition[typeKey]
+
+      // Skip for non-singular, non-typed fields.
+      if (!fieldType || fieldDefinition[isArrayKey]) continue
+
+      range = ranges[field]
+      value = record[field]
+
+      if (value == null) return false
+
+      if (!compare[field]) {
+        compare[field] = fieldType.compare ||
+          find(comparisons, findKey(fieldType))[1]
+        if (!compare[field])
+          throw new Error('Missing "compare" function.')
+      }
+
+      if (range[0] !== null && compare[field](value, range[0]) < 0)
+        return false
+
+      if (range[1] !== null && compare[field](range[1], value) < 0)
         return false
     }
 

--- a/lib/adapter/index.js
+++ b/lib/adapter/index.js
@@ -93,6 +93,7 @@ Adapter.prototype.create = function () {
  *   sort: { ... },
  *   fields: { ... },
  *   match: { ... },
+ *   range: { ... },
  *
  *   // Limit results to this number. Zero means no limit.
  *   limit: 0,
@@ -128,6 +129,20 @@ Adapter.prototype.create = function () {
  * {
  *   name: 'value', // exact match or containment if array
  *   friends: [ 'joe', 'bob' ] // match any one of these values
+ * }
+ * ```
+ *
+ * The `range` object is used to filter between lower and upper bounds. It
+ * should only apply on singular, typed fields, and takes precedence over
+ * `match`.
+ *
+ * ```js
+ * {
+ *   range: { // Ranges should be inclusive.
+ *     age: [ 18, null ], // From 18 and above.
+ *     name: [ 'a', 'd' ], // Starting with letters A through C.
+ *     createdAt: [ null, new Date(2016, 0) ] // Dates until 2016.
+ *   }
  * }
  * ```
  *

--- a/lib/adapter/index.js
+++ b/lib/adapter/index.js
@@ -133,8 +133,8 @@ Adapter.prototype.create = function () {
  * ```
  *
  * The `range` object is used to filter between lower and upper bounds. It
- * should only apply on singular, typed fields, and takes precedence over
- * `match`.
+ * should take precedence over `match`. For array fields, it should apply on
+ * the length of the array. For singular link fields, it should not apply.
  *
  * ```js
  * {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fortune",
   "description": "Application middleware for Node.js and web browsers.",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "license": "MIT",
   "author": {
     "email": "0x8890@airmail.cc",
@@ -34,14 +34,14 @@
     "tapdance": "^4.0.1"
   },
   "devDependencies": {
-    "browserify": "^12.0.1",
+    "browserify": "^12.0.2",
     "cssnext": "^1.8.4",
     "docchi": "^0.11.4",
     "eslint": "^1.10.3",
     "eslint-config-0x8890": "^1.0.1",
     "form-data": "^1.0.0-rc3",
-    "highlight.js": "^9.0.0",
-    "html-minifier": "^1.0.1",
+    "highlight.js": "^9.1.0",
+    "html-minifier": "^1.1.1",
     "http-server": "^0.8.5",
     "inflection": "^1.8.0",
     "marked": "^0.3.5",

--- a/test/unit/adapter.js
+++ b/test/unit/adapter.js
@@ -133,6 +133,56 @@ module.exports = function (adapter, options) {
   })
 
   run(function () {
+    comment('find: range (number)')
+    return test(function (adapter) {
+      return Promise.all([
+        adapter.find(type, null, { range: { age: [ 36, 38 ] } }),
+        adapter.find(type, null, { range: { age: [ null, 36 ] } })
+      ])
+      .then(function (results) {
+        results.forEach(function (records) {
+          ok(records.length === 1, 'match length is correct')
+          ok(records[0].name === 'john', 'matched correct record')
+        })
+      })
+    })
+  })
+
+  run(function () {
+    comment('find: range (string)')
+    return test(function (adapter) {
+      return Promise.all([
+        adapter.find(type, null, { range: { name: [ 'j', null ] } }),
+        adapter.find(type, null, { range: { name: [ 'i', 'k' ] } })
+      ])
+      .then(function (results) {
+        results.forEach(function (records) {
+          ok(records.length === 1, 'match length is correct')
+          ok(records[0].name === 'john', 'matched correct record')
+        })
+      })
+    })
+  })
+
+  run(function () {
+    comment('find: range (date)')
+    return test(function (adapter) {
+      return Promise.all([
+        adapter.find(type, null, { range: {
+          birthday: [ null, new Date() ] } }),
+        adapter.find(type, null, { range: {
+          birthday: [ new Date(Date.now() - 10 * 1000), new Date() ] } })
+      ])
+      .then(function (results) {
+        results.forEach(function (records) {
+          ok(records.length === 1, 'match length is correct')
+          ok(records[0].name === 'bob', 'matched correct record')
+        })
+      })
+    })
+  })
+
+  run(function () {
     comment('find: match (string)')
     return test(function (adapter) {
       return adapter.find(type, null,

--- a/test/unit/adapter.js
+++ b/test/unit/adapter.js
@@ -183,6 +183,24 @@ module.exports = function (adapter, options) {
   })
 
   run(function () {
+    comment('find: range (array)')
+    return test(function (adapter) {
+      return Promise.all([
+        adapter.find(type, null, { range: {
+          privateKeys: [ 1, 2 ] } }),
+        adapter.find(type, null, { range: {
+          privateKeys: [ 1, null ] } })
+      ])
+      .then(function (results) {
+        results.forEach(function (records) {
+          ok(records.length === 1, 'match length is correct')
+          ok(records[0].name === 'john', 'matched correct record')
+        })
+      })
+    })
+  })
+
+  run(function () {
     comment('find: match (string)')
     return test(function (adapter) {
       return adapter.find(type, null,


### PR DESCRIPTION
There is already a sort, so a range filter isn't much of a stretch. It could look something like this:

```js
{
  range: { // Ranges should be inclusive.
    age: [ 18, null ], // From 18 and above.
    name: [ 'a', 'd' ], // Starting with letters A through C.
    createdAt: [ null, new Date(2016, 0) ] // Dates until the beginning of 2016.
  }
}
```

The memory adapter, which is the reference implementation, should also have this functionality.