### PR TITLE
remove listeners on socket close

### DIFF
--- a/lib/net/websocket_server.js
+++ b/lib/net/websocket_server.js
@@ -166,7 +166,22 @@ function ws (instance, change, options, callback) {
       return null
     })
 
-    instance.on(changeEvent, function (changes) {
+    socket.on('close', function () {
+      instance.off(changeEvent, changeListener)
+      process.removeListener('message', ipcListener)
+    })
+
+    instance.on(changeEvent, changeListener)
+
+    if (isWorker && useIPC) process.on('message', ipcListener)
+
+    function ipcListener (message) {
+      var changes = msgpack.decode(new Buffer(message, bufferEncoding))
+      Object.defineProperty(changes, 'fromIPC', { value: true })
+      change(changes)
+    }
+
+    function changeListener (changes) {
       if (!changes.fromIPC && isWorker && useIPC)
         process.send(msgpack.encode(changes).toString(bufferEncoding))
 
@@ -175,14 +190,7 @@ function ws (instance, change, options, callback) {
         if (!changes) return
         socket.send(msgpack.encode({ changes: changes }), sendOptions)
       }, sendError)
-    })
-
-    if (isWorker && useIPC)
-      process.on('message', function (message) {
-        var changes = msgpack.decode(new Buffer(message, bufferEncoding))
-        Object.defineProperty(changes, 'fromIPC', { value: true })
-        change(changes)
-      })
+    }
 
     function sendError (error, id) {
       var data = { error: error.toString() }


### PR DESCRIPTION
Currently the websocket close event is not taken into account. As a result each socket instance still hangs around until the process is closed and "Not opened" errors from the `ws` module are triggered each time a change event occurs in the fortune instance attached to the websocket server.

I'm looking to address this with this pull request