### PR TITLE
Rename "transform" to "hook", make return value optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ An output hook function may optionally return or resolve a record, and it is saf
 ```js
 function output (context, record) {
   record.accessedAt = new Date()
+  return record
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install fortune --save
 
 ## Usage
 
-The only input required is record type definitions. These definitions may have `link`s, or relationships between them, for which Fortune.js does inverse updates and maintains referential integrity. Here's a model of a basic micro-blogging service:
+To get started, only record type definitions need to be passed in. These definitions describe what data types may belong on a record and what relationships they may have, for which Fortune.js does inverse updates and maintains referential integrity. Here's an example of a basic micro-blogging service:
 
 ```js
 const fortune = require('fortune')
@@ -41,7 +41,7 @@ const store = fortune({
 })
 ```
 
-The primary key `id` is reserved, no need to specify this. Links are `id`s that are maintained internally at the application-level by Fortune.js, and are always denormalized. What this means is that changes in a record will affect the links in related records.
+Note that the primary key `id` is reserved, so there is no need to specify this. Links are `id`s that are maintained internally at the application-level by Fortune.js, and are always denormalized so that every link has a back-link. What this also means is that changes in a record will affect the links in related records.
 
 By default, the data is persisted in memory (and IndexedDB for the browser). There are adapters for databases such as [MongoDB](https://github.com/fortunejs/fortune-mongodb), [Postgres](https://github.com/fortunejs/fortune-postgres), and [NeDB](https://github.com/fortunejs/fortune-nedb).
 
@@ -57,7 +57,7 @@ store.request({
 
 The first call to `request` will trigger a connection to the data store, and it returns the result as a Promise. See the [API documentation for `request`](http://fortune.js.org/api/#fortune-request).
 
-**Node.js only**: Fortune.js implements HTTP functionality for convenience, as a plain request listener which may be composed within larger applications.
+**Node.js only**: Fortune.js implements HTTP server functionality for convenience, as a plain request listener which may be composed within larger applications:
 
 ```js
 const http = require('http')
@@ -76,11 +76,11 @@ Fortune.js implements its own [wire protocol](http://fortune.js.org/api/#fortune
 See the [plugins page](http://fortune.js.org/plugins/) for more details.
 
 
-## Transform Functions
+## Input and Output Hooks
 
-Transform functions isolate business logic, and are part of what makes the interface reusable across different protocols. An input and output transform function may be defined per record type. Transform functions accept at least two arguments, the `context` object, the `record`, and optionally the `update` object for an `update` request. The method of an input transform may be any method except `find`, and an output transform may be applied on all methods.
+I/O hooks isolate business logic, and are part of what makes the interface reusable across different protocols. An input and output hook function may be defined per record type. Hook functions accept at least two arguments, the `context` object, the `record`, and optionally the `update` object for an `update` request. The method of an input hook may be any method except `find`, and an output hook may be applied on all methods.
 
-The return value of an input transform function determines what gets persisted, and it is safe to mutate any of its arguments. It may return either the value or a Promise, or throw an error. The returned or resolved value must be the record if it's a create request, the update if it's an update request, or anything (or simply `null`) if it's a delete request. For example, an input transform function for a record may look like this:
+An input hook function may optionally return or resolve a value to determine what gets persisted, and it is safe to mutate any of its arguments. The returned or resolved value must be the record if it's a create request, the update if it's an update request, or anything (or simply `null`) if it's a delete request. For example, an input hook function for a record may look like this:
 
 ```js
 function input (context, record, update) {
@@ -97,24 +97,23 @@ function input (context, record, update) {
 }
 ```
 
-An output transform function may only return a record or Promise that resolves to a record, or throw an error. It is safe to mutate any of its arguments.
+An output hook function may optionally return or resolve a record, and it is safe to mutate any of its arguments.
 
 ```js
 function output (context, record) {
   record.accessedAt = new Date()
-  return record
 }
 ```
 
-Based on whether or not the resolved record is different from what was passed in, serializers may decide not to show the resolved record of the output transform for update and delete requests.
+Based on whether or not the resolved record is different from what was passed in, serializers may decide not to show the resolved record of the output hook for update and delete requests.
 
-**Note**: Tranform functions must be defined in a specific order: input first, output last.
+**Note**: Hook functions must be defined in a specific order: input first, output last.
 
 ```js
 const store = fortune({
   user: { ... }
 }, {
-  transforms: {
+  hooks: {
     user: [ input, output ]
   }
 })

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### 4.1.10 (2016-08-22)
+- Polish: rename "transforms" to "hooks". Documentation has been adjusted accordingly.
+- Feature: hook functions do not need to return or resolve a value, it is now optional.
+
+
 ### 4.1.9 (2016-07-10)
 - Polish: CSS tweaks for HTML serializer.
 

--- a/lib/adapter/adapters/indexeddb/index.js
+++ b/lib/adapter/adapters/indexeddb/index.js
@@ -9,7 +9,6 @@ var common = require('../common')
 var generateId = common.generateId
 
 var constants = require('../../../common/constants')
-var internalKey = constants.internal
 var primaryKey = constants.primary
 
 var worker = require('./worker')
@@ -31,8 +30,6 @@ module.exports = function (Adapter) {
     MemoryAdapter.call(this, properties)
     if (!this.options.name) this.options.name = 'fortune'
   }
-
-  Object.defineProperty(IndexedDBAdapter, internalKey, { value: true })
 
   IndexedDBAdapter.prototype = Object.create(MemoryAdapter.prototype)
 

--- a/lib/adapter/adapters/memory/index.js
+++ b/lib/adapter/adapters/memory/index.js
@@ -3,9 +3,6 @@
 var applyUpdate = require('../../../common/apply_update')
 var map = require('../../../common/array/map')
 
-var constants = require('../../../common/constants')
-var internalKey = constants.internal
-
 var common = require('../common')
 var applyOptions = common.applyOptions
 
@@ -24,8 +21,6 @@ module.exports = function (Adapter) {
     if (!('recordsPerType' in this.options))
       this.options.recordsPerType = 1000
   }
-
-  Object.defineProperty(MemoryAdapter, internalKey, { value: true })
 
   MemoryAdapter.prototype = Object.create(Adapter.prototype)
 

--- a/lib/adapter/singleton.js
+++ b/lib/adapter/singleton.js
@@ -4,9 +4,6 @@ var Adapter = require('./')
 var errors = require('../common/errors')
 var keys = require('../common/keys')
 var message = require('../common/message')
-var assign = require('../common/assign')
-var constants = require('../common/constants')
-var internalKey = constants.internal
 var promise = require('../common/promise')
 
 
@@ -28,20 +25,14 @@ function AdapterSingleton (properties) {
   if (!Adapter.prototype.isPrototypeOf(CustomAdapter.prototype))
     throw new TypeError('The adapter must inherit the Adapter class.')
 
-  return new CustomAdapter(assign({
+  return new CustomAdapter({
     options: input[1] || {},
     recordTypes: properties.recordTypes,
     errors: errors,
     keys: keys,
     message: message,
     Promise: promise.Promise
-  },
-  // The built-in adapters have some optimizations for cloning objects which
-  // are not needed for non-memory adapters.
-  CustomAdapter[internalKey] ?
-    { transforms: properties.transforms } :
-    null
-  ))
+  })
 }
 
 

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -10,8 +10,7 @@ exports.inverse = 'inverse'
 exports.isArray = 'isArray'
 
 // Should be reserved for private use.
-exports.denormalizedInverse = '__denormalizedInverse'
-exports.internal = '__internal'
+exports.denormalizedInverse = '__denormalizedInverse__'
 
 // Events.
 exports.change = 'change'

--- a/lib/core.js
+++ b/lib/core.js
@@ -29,7 +29,7 @@ var message = require('./common/message')
  * - `adapters`: included adapters, defaults to memory adapter. Note that the
  * browser build also includes `indexedDB` and `webStorage` adapters.
  * - `net`: network protocol helpers, varies based on client or server build.
- * - `errors`: custom typed errors, useful for throwing errors in transform
+ * - `errors`: custom typed errors, useful for throwing errors in I/O hook
  * functions.
  * - `methods`: a hash that maps to string constants. Available are: `find`,
  * `create`, `update`, and `delete`.
@@ -115,45 +115,38 @@ Fortune.prototype = Object.create(EventLite.prototype)
  *   }
  *   ```
  *
- * - `transforms`: keyed by type name, valued by an array containing an `input`
+ * - `hooks`: keyed by type name, valued by an array containing an `input`
  *   and/or `output` function at indices `0` and `1` respectively.
  *
- *   A transform function takes at least two arguments, the internal `context`
+ *   A hook function takes at least two arguments, the internal `context`
  *   object and a single `record`. A special case is the `update` argument for
  *   the `update` method.
  *
- *   There are two kinds of transforms, before a record is written to transform
- *   input, and after it is read to transform output, both are optional. If an
- *   error occurs within an transform function, it will be forwarded to the
- *   response. Use typed errors to provide the appropriate feedback. It is
- *   varant to note that `output` transforms are run every time a record is
- *   shown in a response, so it should be idempotent.
+ *   There are only two kinds of hooks, before a record is written (input),
+ *   and after a record is read (output), both are optional. If an error occurs
+ *   within a hook function, it will be forwarded to the response. Use typed
+ *   errors to provide the appropriate feedback.
  *
- *   For a create request, the input transform must return the second argument
+ *   For a create request, the input hook may return the second argument
  *   `record` either synchronously, or asynchronously as a Promise. The return
  *   value of a delete request is inconsequential, but it may return a value or
- *   a Promise. There is a special case of the `update` method accepting a
- *   `update` object as a third parameter, which must be returned synchronously
- *   or as a Promise.
+ *   a Promise. The `update` method accepts a `update` object as a third
+ *   parameter, which may be returned synchronously or as a Promise.
  *
- *   An example transform to apply a timestamp on a record before creation,
- *   and displaying the timestamp in the server's locale:
+ *   An example hook to apply a timestamp on a record before creation, and
+ *   displaying the timestamp in the server's locale:
  *
  *   ```js
  *   {
  *     recordType: [
  *       (context, record, update) => {
- *         const method = context.request.method
- *
- *         if (method === 'create') {
- *           record.timestamp = new Date()
- *           return record
+ *         switch (context.request.method) {
+ *           case 'create':
+ *             record.timestamp = new Date()
+ *             return record
+ *           case 'update': return update
+ *           case 'delete': return null
  *         }
- *
- *         if (update) return update
- *
- *         // If we get here, return value of the delete method doesn't matter.
- *         return null
  *       },
  *       (context, record) => {
  *         record.timestamp = record.timestamp.toLocaleString()
@@ -166,7 +159,7 @@ Fortune.prototype = Object.create(EventLite.prototype)
  *   Requests to update a record will **NOT** have the updates already applied
  *   to the record.
  *
- *   Another feature of the input transform is that it will have access to a
+ *   Another feature of the input hook is that it will have access to a
  *   temporary field `context.transaction`. This is useful for ensuring that
  *   bulk write operations are all or nothing. Each request is treated as a
  *   single transaction.
@@ -214,7 +207,7 @@ Fortune.prototype = Object.create(EventLite.prototype)
  */
 Fortune.prototype.constructor = function (recordTypes, options) {
   var self = this
-  var adapter, method, stack, flows, type, transforms, i, j
+  var adapter, method, stack, flows, type, hooks, i, j
 
   if (typeof recordTypes !== 'object')
     throw new TypeError('First argument must be an object.')
@@ -222,9 +215,12 @@ Fortune.prototype.constructor = function (recordTypes, options) {
   if (!Object.keys(recordTypes).length)
     throw new Error('At least one type must be specified.')
 
+  // DEPRECATION: "transforms" has been deprecated in favor of "hooks".
+  if ('transforms' in options) options.hooks = options.transforms
+
   if (!('adapter' in options)) options.adapter = [ memoryAdapter ]
   if (!('settings' in options)) options.settings = {}
-  if (!('transforms' in options)) options.transforms = {}
+  if (!('hooks' in options)) options.hooks = {}
   if (!('enforceLinks' in options.settings))
     options.settings.enforceLinks = true
 
@@ -239,22 +235,22 @@ Fortune.prototype.constructor = function (recordTypes, options) {
     flows[methods[method]] = stack
   }
 
-  transforms = options.transforms
+  hooks = options.hooks
 
-  // Validate transforms.
-  for (type in transforms) {
+  // Validate hooks.
+  for (type in hooks) {
     if (!(type in recordTypes)) throw new Error(
-      'Attempted to define transform on "' + type + '" type ' +
+      'Attempted to define hook on "' + type + '" type ' +
       'which does not exist.')
-    if (!Array.isArray(transforms[type]))
-      throw new TypeError('Transform value for "' + type + '" type ' +
+    if (!Array.isArray(hooks[type]))
+      throw new TypeError('Hook value for "' + type + '" type ' +
         'must be an array.')
   }
 
   // Validate record types.
   for (type in recordTypes) {
     validate(recordTypes[type])
-    if (!(type in transforms)) transforms[type] = []
+    if (!(type in hooks)) hooks[type] = []
   }
 
   /*!
@@ -265,7 +261,7 @@ Fortune.prototype.constructor = function (recordTypes, options) {
   adapter = new AdapterSingleton({
     adapter: options.adapter,
     recordTypes: recordTypes,
-    transforms: transforms
+    hooks: hooks
   })
 
   // Internal properties.
@@ -275,7 +271,7 @@ Fortune.prototype.constructor = function (recordTypes, options) {
 
     // Configuration settings.
     options: { value: options },
-    transforms: { value: transforms },
+    hooks: { value: hooks },
     recordTypes: { value: recordTypes, enumerable: true },
 
     // Singleton instances.

--- a/lib/dispatch/create.js
+++ b/lib/dispatch/create.js
@@ -36,10 +36,10 @@ module.exports = function (context) {
   var Promise = promise.Promise
   var adapter = self.adapter
   var recordTypes = self.recordTypes
-  var transforms = self.transforms
+  var hooks = self.hooks
   var updates = {}
   var links = []
-  var transaction, records, type, meta, transform, fields, language
+  var transaction, records, type, meta, hook, fields, language
 
   // Start a promise chain.
   return Promise.resolve(context.request.payload)
@@ -56,7 +56,7 @@ module.exports = function (context) {
     meta = context.request.meta
     language = meta.language
 
-    transform = transforms[type]
+    hook = hooks[type]
     fields = recordTypes[type]
 
     for (field in fields) {
@@ -75,26 +75,26 @@ module.exports = function (context) {
   .then(function (result) {
     context.transaction = transaction = result
 
-    return typeof transform[0] === 'function' ?
+    return typeof hook[0] === 'function' ?
       Promise.all(map(records, function (record) {
-        return transform[0](context, record)
+        return hook[0](context, record)
       })) : records
   })
 
   .then(function (results) {
-    records = results
+    return Promise.all(map(results, function (record, i) {
+      if (record) records[i] = record
+      else record = records[i]
 
-    return Promise.all(map(records, function (record) {
       // Enforce the fields.
       enforce(type, record, fields, meta)
 
       // Ensure referential integrity.
       return checkLinks.call(self, record, fields, links, meta)
-      .then(function () { return record })
     }))
   })
 
-  .then(function (records) {
+  .then(function () {
     validateRecords.call(self, records, fields, links, meta)
     return transaction.create(type, records, meta)
   })
@@ -107,16 +107,16 @@ module.exports = function (context) {
     // Trying to batch updates to be as few as possible.
     var idCache = {}
 
+    // Adapter must return something.
+    if (!createdRecords.length)
+      throw new BadRequestError(message('CreateRecordsFail', language))
+
     records = createdRecords
 
     Object.defineProperty(context.response, 'records', {
       configurable: true,
       value: records
     })
-
-    // Adapter must return something.
-    if (!records.length)
-      throw new BadRequestError(message('CreateRecordsFail', language))
 
     // Iterate over each record to generate updates object.
     for (i = 0, j = records.length; i < j; i++) {

--- a/lib/dispatch/delete.js
+++ b/lib/dispatch/delete.js
@@ -36,10 +36,10 @@ module.exports = function (context) {
   var language = meta.language
   var adapter = self.adapter
   var recordTypes = self.recordTypes
-  var transforms = self.transforms
+  var hooks = self.hooks
   var updates = {}
   var fields = recordTypes[type]
-  var transform = transforms[type]
+  var hook = hooks[type]
   var links = []
   var transaction, field, records
 
@@ -67,9 +67,9 @@ module.exports = function (context) {
   .then(function (result) {
     context.transaction = transaction = result
 
-    return typeof transform[0] === 'function' ?
+    return typeof hook[0] === 'function' ?
       Promise.all(map(records, function (record) {
-        return transform[0](context, record)
+        return hook[0](context, record)
       })) : records
   })
 

--- a/lib/dispatch/end.js
+++ b/lib/dispatch/end.js
@@ -5,17 +5,17 @@ var promise = require('../common/promise')
 
 
 /**
- * Apply `output` transform per record, this mutates `context.response`.
+ * Apply `output` hook per record, this mutates `context.response`.
  *
  * @return {Promise}
  */
 module.exports = function (context) {
   var Promise = promise.Promise
-  var transforms = this.transforms
+  var hooks = this.hooks
   var request = context.request
   var response = context.response
   var type = request.type
-  var transform = transforms[type]
+  var hook = hooks[type]
   var records = response.records
   var include = response.include
 
@@ -27,10 +27,10 @@ module.exports = function (context) {
   // at this point.
   delete context.transaction
 
-  // Run transforms on primary type.
+  // Run hooks on primary type.
   return (records ? Promise.all(map(records, function (record) {
-    return Promise.resolve(typeof transform[1] === 'function' ?
-      transform[1](context, record) : record)
+    return Promise.resolve(typeof hook[1] === 'function' ?
+      hook[1](context, record) : record)
   }))
 
   .then(function (updatedRecords) {
@@ -38,42 +38,40 @@ module.exports = function (context) {
     var i, j
 
     for (i = 0, j = updatedRecords.length; i < j; i++)
-      records[i] = updatedRecords[i]
+      if (updatedRecords[i]) records[i] = updatedRecords[i]
 
     if (!include) return void 0
 
-    // The order of the keys and their corresponding indices matter. Since it
-    // is an associative array, we are not guaranteed any particular order,
-    // but the order that we get matters.
+    // The order of the keys and their corresponding indices matter.
     includeTypes = Object.keys(include)
 
-    // Run output transforms per include type.
+    // Run output hooks per include type.
     return Promise.all(map(includeTypes, function (includeType) {
       return Promise.all(map(include[includeType], function (record) {
         return Promise.resolve(
-          typeof transforms[includeType][1] === 'function' ?
-            transforms[includeType][1](context, record) : record)
+          typeof hooks[includeType][1] === 'function' ?
+            hooks[includeType][1](context, record) : record)
       }))
     }))
 
     .then(function (types) {
-      var include = {}
-      var i, j
+      var i, j, k, l
 
+      // Assign results of output hooks on includes.
       for (i = 0, j = types.length; i < j; i++)
-        include[includeTypes[i]] = types[i]
-
-      return include
+        for (k = 0, l = types[i].length; k < l; k++)
+          if (types[i][k]) include[includeTypes[i]][k] = types[i][k]
     })
   }) : Promise.resolve())
 
-  .then(function (include) {
+  .then(function () {
     context.response.payload = {
       records: records
     }
 
     if (include) context.response.payload.include = include
 
+    // Expose the "count" property so that it is serializable.
     if (records && 'count' in records)
       context.response.payload.count = records.count
 

--- a/lib/dispatch/update.js
+++ b/lib/dispatch/update.js
@@ -34,7 +34,7 @@ var denormalizedInverseKey = constants.denormalizedInverse
 
 
 /**
- * Do updates. First, it must find the records to update, then run transforms
+ * Do updates. First, it must find the records to update, then run hooks
  * and validation, then apply the update as well as links on related records.
  *
  * @return {Promise}
@@ -44,7 +44,7 @@ module.exports = function (context) {
   var Promise = promise.Promise
   var adapter = self.adapter
   var recordTypes = self.recordTypes
-  var transforms = self.transforms
+  var hooks = self.hooks
 
   // Keyed by update, valued by record.
   var updateMap = new WeakMap()
@@ -53,10 +53,10 @@ module.exports = function (context) {
   var linkedMap = new WeakMap()
 
   var relatedUpdates = {}
-  var transformedUpdates = []
+  var hookedUpdates = []
 
   var links = []
-  var transaction, updates, fields, transform, type, meta, language
+  var transaction, updates, fields, hook, type, meta, language
 
   // Start a promise chain.
   return Promise.resolve(context.request.payload)
@@ -72,7 +72,7 @@ module.exports = function (context) {
     language = meta.language
 
     fields = recordTypes[type]
-    transform = transforms[type]
+    hook = hooks[type]
 
     // Delete denormalized inverse fields, can't be updated.
     for (field in fields) {
@@ -100,7 +100,7 @@ module.exports = function (context) {
   .then(function (records) {
     return Promise.all(map(records, function (record) {
       var update, cloneUpdate
-      var hasTransform = typeof transform[0] === 'function'
+      var hasHook = typeof hook[0] === 'function'
       var id = record[primaryKey]
 
       update = find(updates, function (update) {
@@ -110,12 +110,14 @@ module.exports = function (context) {
       if (!update) throw new NotFoundError(
         message('UpdateRecordMissing', language))
 
-      if (hasTransform) cloneUpdate = clone(update)
+      if (hasHook) cloneUpdate = clone(update)
 
-      return Promise.resolve(hasTransform ?
-        transform[0](context, record, update) : update)
-      .then(function (update) {
-        if (hasTransform) {
+      return Promise.resolve(hasHook ?
+        hook[0](context, record, update) : update)
+      .then(function (result) {
+        if (result) update = result
+
+        if (hasHook) {
           // Check if the update has been modified or not.
           if (!deepEqual(update, cloneUpdate))
             context.response.meta.updateModified = true
@@ -125,7 +127,7 @@ module.exports = function (context) {
             message('InvalidID', language))
         }
 
-        transformedUpdates.push(update)
+        hookedUpdates.push(update)
         updateMap.set(update, record)
 
         // Shallow clone the record.
@@ -163,10 +165,10 @@ module.exports = function (context) {
 
     // Drop fields in the updates that aren't defined in the record type
     // before doing the update.
-    for (i = 0, j = transformedUpdates.length; i < j; i++)
-      dropFields(transformedUpdates[i], fields)
+    for (i = 0, j = hookedUpdates.length; i < j; i++)
+      dropFields(hookedUpdates[i], fields)
 
-    return transaction.update(type, transformedUpdates, meta)
+    return transaction.update(type, hookedUpdates, meta)
   })
 
   .then(function () {
@@ -178,8 +180,8 @@ module.exports = function (context) {
     var idCache = {}
 
     // Iterate over each update to generate related updates.
-    for (i = 0, j = transformedUpdates.length; i < j; i++) {
-      update = transformedUpdates[i]
+    for (i = 0, j = hookedUpdates.length; i < j; i++) {
+      update = hookedUpdates[i]
 
       for (k = 0, l = links.length; k < l; k++) {
         field = links[k]
@@ -346,7 +348,7 @@ module.exports = function (context) {
     var eventData = {}, linkedType
 
     eventData[updateMethod] = {}
-    eventData[updateMethod][type] = transformedUpdates
+    eventData[updateMethod][type] = hookedUpdates
 
     for (linkedType in relatedUpdates) {
       if (!relatedUpdates[linkedType].length) continue

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fortune",
   "description": "Database abstraction layer for Node.js and web browsers.",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "license": "MIT",
   "author": {
     "email": "0x8890@airmail.cc",

--- a/test/integration/adapters/memory.js
+++ b/test/integration/adapters/memory.js
@@ -29,7 +29,6 @@ const adapter = new MemoryAdapter({
   keys: keys,
   errors: errors,
   recordTypes: recordTypes,
-  transforms: {},
   Promise: Promise
 })
 

--- a/test/integration/methods/create.js
+++ b/test/integration/methods/create.js
@@ -66,7 +66,7 @@ run(() => {
     ok(deadcode.equals(results[0].picture) &&
       deadcode.equals(records[0].picture),
       'input object not mutated')
-    ok(results[0].createdAt !== null, 'transform applied')
+    ok(results[0].createdAt !== null, 'input hook applied')
     ok(results.length === 1, 'record created')
     ok(results[0][primaryKey] === 4, 'record has correct ID')
     ok(results[0].birthday instanceof Date,

--- a/test/integration/test_instance.js
+++ b/test/integration/test_instance.js
@@ -52,24 +52,19 @@ module.exports = () => {
     },
     '☯': {}
   }, {
-    transforms: {
+    hooks: {
       user: [
         function input (context, record, update) {
-          const method = context.request.method
+          switch (context.request.method) {
+            case methods.create:
+              record.createdAt = new Date()
+              return record
 
-          if (method === methods.create)
-            return assign({}, record, {
-              createdAt: new Date()
-            })
-
-          if (method === methods.update) {
-            if (!('replace' in update)) update.replace = {}
-            update.replace.lastModifiedAt = new Date()
-            return update
+            case methods.update:
+              if (!('replace' in update)) update.replace = {}
+              update.replace.lastModifiedAt = new Date()
+              return update
           }
-
-          // For the `delete` method, return value doesn't matter.
-          return null
         },
         function output (context, record) {
           record.timestamp = Date.now()
@@ -78,21 +73,17 @@ module.exports = () => {
       ],
       animal: [
         function input (context, record, update) {
-          const method = context.request.method
+          switch (context.request.method) {
+            case methods.create:
+              return assign({}, record, {
+                createdAt: new Date()
+              })
 
-          if (method === methods.create)
-            return assign({}, record, {
-              createdAt: new Date()
-            })
-
-          if (method === methods.update) {
-            if (!('replace' in update)) update.replace = {}
-            update.replace.lastModifiedAt = new Date()
-            return update
+            case methods.update:
+              if (!('replace' in update)) update.replace = {}
+              update.replace.lastModifiedAt = new Date()
+              return update
           }
-
-          // For the `delete` method, return value doesn't matter.
-          return null
         },
         function output (context, record) {
           record.virtualProperty = 123

--- a/test/unit/adapter.js
+++ b/test/unit/adapter.js
@@ -20,6 +20,7 @@ const includes = require('../../lib/common/array/includes')
 const filter = require('../../lib/common/array/filter')
 
 const keys = require('../../lib/common/keys')
+const denormalizedInverseKey = keys.denormalizedInverse
 const primaryKey = keys.primary
 
 const type = 'user'
@@ -37,7 +38,7 @@ const recordTypes = {
     friends: { link: 'user', isArray: true, inverse: 'friends' },
     nemesis: { link: 'user', inverse: '__user_nemesis_inverse' },
     '__user_nemesis_inverse': { link: 'user', isArray: true,
-      inverse: 'nemesis', '__denormalizedInverse': true },
+      inverse: 'nemesis', [denormalizedInverseKey]: true },
     bestFriend: { link: 'user', inverse: 'bestFriend' }
   }
 }
@@ -572,7 +573,6 @@ function runTest (a, options, fn) {
     errors: errors,
     message: message,
     recordTypes: recordTypes,
-    transforms: {},
     Promise: Promise
   })
 

--- a/website/stylesheets/home.css
+++ b/website/stylesheets/home.css
@@ -11,7 +11,7 @@ p.intro {
   color: var(--color-literal);
   font-size: 2em;
   line-height: var(--line-height);
-  padding: calc(var(--line-height) * 1 / 2) 0 calc(var(--line-height) * 1 / 2);
+  padding-bottom: calc(var(--line-height) * 1 / 2);
   margin: 0;
 }
 

--- a/website/stylesheets/home.css
+++ b/website/stylesheets/home.css
@@ -9,9 +9,9 @@ article > h1.intro::before {
 
 p.intro {
   color: var(--color-literal);
-  font-size: 2em;
+  font-size: calc(1em * 2);
   line-height: var(--line-height);
-  padding-bottom: calc(var(--line-height) * 3 / 4);
+  padding-bottom: calc(var(--line-height) * 1 / 2);
   margin: 0;
 }
 

--- a/website/stylesheets/home.css
+++ b/website/stylesheets/home.css
@@ -11,7 +11,7 @@ p.intro {
   color: var(--color-literal);
   font-size: 2em;
   line-height: var(--line-height);
-  padding-bottom: calc(var(--line-height) * 1 / 2);
+  padding-bottom: calc(var(--line-height) * 3 / 4);
   margin: 0;
 }
 

--- a/website/stylesheets/page.css
+++ b/website/stylesheets/page.css
@@ -251,6 +251,15 @@ article > h1:first-of-type::before {
   background: rgba(0, 0, 0, 0.12);
 }
 
+article > h1:first-of-type {
+  margin-bottom: calc(var(--line-height) * 3 / 2 * 8 / 7);
+}
+
+article > h1:first-of-type + h2,
+article > h1:first-of-type + h3 {
+  margin-top: calc(var(--line-height) * -3 * (5 / 7));
+}
+
 nav ul {
   list-style-type: none;
   padding: 0;

--- a/website/templates/home.mustache
+++ b/website/templates/home.mustache
@@ -1,3 +1,3 @@
 <h1 class="intro">Readme</h1>
-<p class="intro">Fortune.js is a <a href="https://en.wikipedia.org/wiki/Database_abstraction_layer">database abstraction layer</a> for Node.js and web browsers, networking included.</p>
+<p class="intro">Fortune.js is a <a href="https://en.wikipedia.org/wiki/Database_abstraction_layer">database abstraction layer</a> for Node.js and web browsers.</p>
 <pre class="install"><code><a href="/fortune.min.js">npm install fortune --save</a></code></pre>

--- a/website/templates/home.mustache
+++ b/website/templates/home.mustache
@@ -1,3 +1,3 @@
 <h1 class="intro">Readme</h1>
-<p class="intro">Fortune.js is a <a href="https://en.wikipedia.org/wiki/Database_abstraction_layer">database abstraction layer</a> for Node.js and web browsers.</p>
+<p class="intro">Fortune.js is a <a href="https://en.wikipedia.org/wiki/Database_abstraction_layer">database abstraction layer</a> for Node.js and web browsers, networking included.</p>
 <pre class="install"><code><a href="/fortune.min.js">npm install fortune --save</a></code></pre>


### PR DESCRIPTION
This PR does two things:
1. Rename "transform" to "hook" everywhere.
2. Make return value of I/O hooks optional.