### PR TITLE
adds UnprocessableError class to allow for correct 422 errors inline …

### DIFF
--- a/lib/common/errors.js
+++ b/lib/common/errors.js
@@ -10,4 +10,5 @@ exports.MethodError = responseClass.MethodError
 exports.NotAcceptableError = responseClass.NotAcceptableError
 exports.ConflictError = responseClass.ConflictError
 exports.UnsupportedError = responseClass.UnsupportedError
+exports.UnprocessableError = responseClass.UnprocessableError
 exports.nativeErrors = responseClass.nativeErrors

--- a/lib/common/response_classes.js
+++ b/lib/common/response_classes.js
@@ -19,6 +19,7 @@ exports.MethodError = errorClass('MethodError')
 exports.NotAcceptableError = errorClass('NotAcceptableError')
 exports.ConflictError = errorClass('ConflictError')
 exports.UnsupportedError = errorClass('UnsupportedError')
+exports.UnprocessableError = errorClass('UnprocessableError')
 
 
 // White-list native error types. The list is gathered from here:


### PR DESCRIPTION
…with JsonApi Spec as used by Ember Js. [Documentation](https://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)