### PR TITLE
Fix incorrect detection of `include` shorthand

### DIFF
--- a/lib/dispatch/include.js
+++ b/lib/dispatch/include.js
@@ -50,7 +50,7 @@ module.exports = function include (context) {
     }
 
   // Cast `include` into an array if it's using shorthand.
-  if (!Array.isArray(include[0])) include = [ include ]
+  if (include[0] && !Array.isArray(include[0])) include = [ include ]
 
   return Promise.all(map(include, function (fields) {
     return new Promise(function (resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "postcss-cssnext": "^2.11.0",
     "postcss-import": "^10.0.0",
     "rimraf": "^2.6.1",
+    "spy": "^1.0.0",
     "tapdance": "^5.0.4",
     "tape-run": "^3.0.0",
     "uglify-js": "^3.0.22"


### PR DESCRIPTION
As of v5.2.3, finding records by type triggers not just a query for the records, but also queries for the value of a column named `undefined` for each record, as well. For example, if there were three `user` records in a table and they were fetched using `fortuneInstance.find('user')`, the `find()` method of the adapter would be called four times. The arguments for each call would be

1. `[ 'user', [], {}, {} ]`
2. `[ 'user', [ 1 ], { fields: { undefined: true } }, {} ]`
3. `[ 'user', [ 2 ], { fields: { undefined: true } }, {} ]`
4. `[ 'user', [ 3 ], { fields: { undefined: true } }, {} ]`

Besides doing unnecessary work, this is a major issue when using the Postgres adapter, which throws a `column "undefined" does not exist` error when attempting to find any records. This doesn't affect the memory adapter since it doesn't throw an error when the column name doesn't exist.

The issue seems to be caused by the way the `include` shorthand is detected. When initiating a request, if the `include` option is an empty array, Fortune assumes that the shorthand is being used and casts the empty array into an array. When the array is mapped, the name of the included field is determined to be `undefined` (since `include[0][0]` is `undefined`) which then triggers the additional queries.

The fix involves simply checking first if `include` is empty before casting it into an array.

In addition to the fix I added a test that spies on the adapter’s `find` method and verifies that it’s only called once. (This was the best approach I could find, but I'm happy to refactor if there's something better.) In order to do the spying, I added the package `spy`, which uses an implementation like Sinon’s `spy`, as a dev dependency.