### PR TITLE
Include findRecords in meta for update and delete

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -11,7 +11,10 @@ var privateKeys = [
   'updateRecord',
 
   // Used to map update objects to a hash of linked records.
-  'linkedHash'
+  'linkedHash',
+
+  // Used to include find records in `meta` for update and delete requests.
+  'findRecords'
 ]
 
 // The primary key that must exist per record, can not be user defined.

--- a/lib/common/keys.js
+++ b/lib/common/keys.js
@@ -8,3 +8,4 @@ exports.link = constants.link
 exports.isArray = constants.isArray
 exports.inverse = constants.inverse
 exports.denormalizedInverse = constants.denormalizedInverse
+exports.findRecords = constants.findRecords

--- a/lib/dispatch/delete.js
+++ b/lib/dispatch/delete.js
@@ -20,6 +20,7 @@ var primaryKey = constants.primary
 var linkKey = constants.link
 var inverseKey = constants.inverse
 var isArrayKey = constants.isArray
+var findRecordsKey = constants.findRecords
 
 
 /**
@@ -62,6 +63,10 @@ module.exports = function (context) {
 
       Object.defineProperty(context.response, 'records', {
         configurable: true,
+        value: records
+      })
+
+      Object.defineProperty(meta, findRecordsKey, {
         value: records
       })
 

--- a/lib/dispatch/update.js
+++ b/lib/dispatch/update.js
@@ -34,6 +34,7 @@ var isArrayKey = constants.isArray
 var denormalizedInverseKey = constants.denormalizedInverse
 var updateRecordKey = constants.updateRecord
 var linkedHashKey = constants.linkedHash
+var findRecordsKey = constants.findRecords
 
 
 /**
@@ -93,6 +94,10 @@ module.exports = function (context) {
     .then(function (records) {
       if (records.length < updates.length)
         throw new NotFoundError(message('UpdateRecordMissing', language))
+
+      Object.defineProperty(meta, findRecordsKey, {
+        value: records
+      })
 
       return Promise.all(map(records, function (record) {
         var update, cloneUpdate

--- a/lib/index.js
+++ b/lib/index.js
@@ -343,8 +343,10 @@ Fortune.prototype.constructor = function Fortune (recordTypes, options) {
  *   options in the adapter. These options do not apply on methods other than
  *   `find`, and do not affect the records returned from `include`. Optional.
  *
- * - `meta`: Meta-information object of the request. Optional.
- *
+ * - `meta`: Meta-information object of the request. For `update` and `delete`
+ *   requests, this will contain `findRecords` with results of `find` called 
+ *   during validation of record existence. Optional.
+ * 
  * - `payload`: Payload of the request. **Required** for `create` and `update`
  *   methods only, and must be an array of objects. The objects must be the
  *   records to create, or update objects as expected by the Adapter.


### PR DESCRIPTION
For `update` and `delete` requests, `meta` object will contain `findRecords` with results of `find` called during validation of record existence. 

See #289