### PR TITLE
Support 'displayName' property on custom types

### DIFF
--- a/lib/record_type/enforce.js
+++ b/lib/record_type/enforce.js
@@ -112,21 +112,22 @@ module.exports = function enforce (type, record, fields, meta) {
 function checkValue (field, key, value, meta) {
   var language = meta.language
   var check
+  var type = field[typeKey]
 
   // Skip `null` case.
   if (value === null) return
 
   check = find(checkInput, function (pair) {
-    return pair[0] === field[typeKey]
+    return pair[0] === type
   })
   if (check) check = check[1]
-  else check = field[typeKey]
+  else check = type
 
   // Fields may be nullable, but if they're defined, then they must be defined
   // properly.
   if (!check(value)) throw new BadRequestError(
     message(field[isArrayKey] ? 'EnforceValueArray' : 'EnforceValue',
-      language, { key: key, type: field[typeKey].name }))
+      language, { key: key, type: type.displayName || type.name }))
 }
 
 


### PR DESCRIPTION
### Motivation

This helps the API return more useful errors when using a factory pattern to create custom types. Here's an example of how it would work:

```js
function makeEnum(name, values) {
  function Enum(value) {
    // Validate that the assigned value is one of the possible enum values.
    return value >= 0 && value < values.length;
  }
  Enum.prototype = Number();
  Enum.displayName = name;

  return Enum;
}

const store = fortune({
  item: {
    state: { type: makeEnum('ItemState', ['open', 'closed']) },
  },
});
```

### Changes

With this change, instead of returning

```
BadRequestError
The value of "state" is invalid, it must be a "Enum".
```

The API will now return

```
BadRequestError
The value of "state" is invalid, it must be a "ItemState".
```

### Notes

`displayName` is a common non-standard property. You can find docs here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName

I'm happy to make any tweaks if you need me to. Thanks!