### PR TITLE
Fixes fortunejs/fortune#308 update inverse relationships on delete

### DIFF
--- a/lib/request/delete.js
+++ b/lib/request/delete.js
@@ -77,7 +77,8 @@ module.exports = function (context) {
 
     .then(function (count) {
       var i, j, k, l, m, n, record, field, id, inverseField,
-        linkedType, linkedIsArray, linkedIds
+        linkedType, linkedIsArray, linkedIds, denormalizedFieldKeys,
+        iTypeSplit, iField, iTypeAndField
 
       // Remove all instances of the deleted IDs in all records.
       var idCache = {}
@@ -89,6 +90,39 @@ module.exports = function (context) {
       // Loop over each record to generate updates object.
       for (i = 0, j = records.length; i < j; i++) {
         record = records[i]
+
+        // First deal with hidden inversefield updates
+        denormalizedFieldKeys = Object.keys(denormalizedFields)
+
+        for (k = 0, l = denormalizedFieldKeys.length; k < l; k++) {
+          iTypeAndField = denormalizedFieldKeys[k]
+
+          if (!record[iTypeAndField]) continue
+
+          iTypeSplit = iTypeAndField
+            .substring(2).split('_').filter(function (k) {
+              return k !== inverseKey
+            })
+
+          linkedType = iTypeSplit[0]
+          iField = iTypeSplit[1]
+
+          linkedIsArray = recordTypes[linkedType][iField][isArrayKey]
+          linkedIds = Array.isArray(record[iTypeAndField]) ?
+            record[iTypeAndField] : [ record[iTypeAndField] ]
+
+          if (!updates[linkedType]) updates[linkedType] = []
+          if (!idCache[linkedType]) idCache[linkedType] = {}
+
+          for (m = 0, n = linkedIds.length; m < n; m++) {
+            id = linkedIds[m]
+            if (id !== null)
+              removeId(record[primaryKey],
+                getUpdate(linkedType, id, updates, idCache),
+                iField, linkedIsArray)
+          }
+        }
+
         for (k = 0, l = links.length; k < l; k++) {
           field = links[k]
           inverseField = fields[field][inverseKey]

--- a/test/integration/methods/delete.js
+++ b/test/integration/methods/delete.js
@@ -27,9 +27,12 @@ run((assert, comment) => {
     store.on(changeEvent, data => {
       assert(find(data[deleteMethod].user, id => id === 3),
         'change event shows deleted ID')
+      assert(find(data[updateMethod].user, (update) => {
+        return update.id === 2 && update.pull.enemies[0] === 3
+      }), 'user 3 is removed from user 2 enemies')
       assert(deepEqual(data[updateMethod].user
         .map(x => x.id).sort((a, b) => a - b),
-        [ 1, 2 ]), 'change event shows updated IDs')
+        [ 1, 2, 2 ]), 'change event shows updated IDs')
     })
 
     return store.delete('user', 3)


### PR DESCRIPTION
This will fix updating of relationships that are in hidden inverse fields.

Also added a test to check that `user 3` is pulled from `user 2` enemies (which is inverse relation) and fixed faulty test as it did not take account the new pull update.