### PR TITLE
skip update deletion if record does not have inversefield

### DIFF
--- a/lib/request/delete.js
+++ b/lib/request/delete.js
@@ -95,6 +95,9 @@ module.exports = function (context) {
 
         for (k = 0, l = links.length; k < l; k++) {
           field = links[k]
+
+          if (!record[field]) continue
+
           inverseField = fields[field][inverseKey]
 
           if (!record.hasOwnProperty(field) || !inverseField) continue

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -86,3 +86,21 @@ exports.animal = [
     isNeutered: false
   }
 ]
+
+exports.article = [
+  {
+    id: 1,
+    title: 'Title',
+    body: 'Something here',
+    // Hidden denormalized field
+    '__comment_article_inverse': 1
+  }
+]
+
+exports.comment = [
+  {
+    id: 1,
+    text: 'Comment to article 1',
+    article: 1
+  }
+]

--- a/test/integration/test_instance.js
+++ b/test/integration/test_instance.js
@@ -56,6 +56,14 @@ module.exports = adapter => {
       // One to many
       owner: { link: 'user', inverse: 'ownedPets' }
     },
+    article: {
+      title: { type: String },
+      body:{ type: String }
+    },
+    comment: {
+      text: { type: String },
+      article: { link: 'article' }
+    },
     '☯': {}
   }, assign({
     hooks: {


### PR DESCRIPTION
In the latest version there was a fix to add hidden inverse fields to update:
https://github.com/fortunejs/fortune/commit/5120dbd168d0f4d2460ed20081ad518ad2a175cf

Unfortunately this created another bug which the tests could not catch.

In the fix the denormalized fields are pushed to links here:

https://github.com/fortunejs/fortune/blob/5120dbd168d0f4d2460ed20081ad518ad2a175cf/lib/request/delete.js#L52-L53

And because `denomarlizedFields` contains fields from ALL types, this will fail with error:

https://github.com/fortunejs/fortune/blob/5120dbd168d0f4d2460ed20081ad518ad2a175cf/lib/request/delete.js#L98

The error is `Cannot read property 'inverse' of undefined`

Testinstance has 2 types which are related to each other and that is why the tests pass. Adding non related types and records to testinstance will fail with that error.