### PR TITLE
fix updates cache

### DIFF
--- a/lib/request/update_helpers.js
+++ b/lib/request/update_helpers.js
@@ -19,7 +19,7 @@ exports.getUpdate = function (type, id, updates, cache) {
   update = { id: id }
   if (!updates[type]) updates[type] = []
   updates[type].push(update)
-  cache[type] = cache[type] || {}
+  if (!cache[type]) cache[type] = {}
   cache[type][id] = true
   return update
 }

--- a/lib/request/update_helpers.js
+++ b/lib/request/update_helpers.js
@@ -19,7 +19,7 @@ exports.getUpdate = function (type, id, updates, cache) {
   update = { id: id }
   if (!updates[type]) updates[type] = []
   updates[type].push(update)
-  cache[type] = {}
+  cache[type] = cache[type] || {}
   cache[type][id] = true
   return update
 }


### PR DESCRIPTION
The pull request is intended to fix batch updates of nodes.

It fixes the case when there are multiple updates of inverse relations of the same node.
Right now adapter receives updates array like:
```
[
{ id: "1", push: { inverseField: ["11"] } },
{ id: "2", push: { inverseField: ["11"] } },
{ id: "1", push: { inverseField: ["12"] } }
]
```

And with these changes. The array looks like:
```
[
{ id: "1", push: { inverseField: ["11", "12"] } },
{ id: "2", push: { inverseField: ["11"] } }
]
```

It fixes batch updates at least for indexeddb adapter.